### PR TITLE
Add new credit card button

### DIFF
--- a/src/components/bank-account/BankAccountBalance.tsx
+++ b/src/components/bank-account/BankAccountBalance.tsx
@@ -20,7 +20,7 @@ const BankAccountBalanceCard = ({ account, income=0, expensses=0, onSendClick, o
     return (
         <Card
             className={cn(
-                "border-0 p-6 flex flex-col lg:flex-row lg:items-center justify-center ",
+                "border-0 h-full p-6 flex flex-col lg:flex-row lg:items-center justify-center ",
                 className
             )}
             {...props}

--- a/src/components/bank-account/BankAccountCards.tsx
+++ b/src/components/bank-account/BankAccountCards.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "@/components/ui/card";
 import {BankAccount} from "@/types/bankAccount.ts";
 import React from "react";
 import {CardSwipe} from "@/components/ui/card-swipe.tsx";
@@ -9,14 +9,76 @@ import {CardType} from "@/types/cardType.ts";
 import {format} from "date-fns";
 import {useNavigate} from "react-router-dom";
 import {Tooltip, TooltipProvider, TooltipTrigger, TooltipContent} from "@/components/ui/tooltip.tsx";
+import {Button} from "@/components/ui/button.tsx";
 
 
 interface BalanceCardProps extends React.ComponentProps<"div">{
     account: BankAccount,
 }
 
+const NewCreditCardButton = (
+        <Button
+            className="w-fit"
+            variant="success"
+            onClick={() => {/*TODO: Create card dialog open*/}}
+        >
+            <span className="icon-[ph--plus] text-lg"></span>
+            Create a new credit card
+
+        </Button>
+)
+
+const CreditCardSwipe = (account: BankAccount, cards : CardEntity[], handleCardClick: (id: string) => void) => {
+    return (
+        <div className="flex flex-col w-full items-center gap-4">
+            <TooltipProvider>
+
+                <CardSwipe
+                    elements={cards.map((card) => (
+                        <Tooltip>
+                            {/* Wrap tooltip content in TooltipTrigger */}
+                            <TooltipTrigger>
+
+                                <div
+                                    onClick={() => handleCardClick(card.id)}
+                                    className="cursor-pointer inline-block w-full"
+                                    onMouseDown={(e) => e.preventDefault()}
+                                >
+                                    <CreditCard
+                                        title={card.name}
+                                        cardHolder={`${card.account.client.firstName} ${card.account.client.lastName}`}
+                                        cardNumber={card.number}
+                                        expiryDate={format(card.expiresAt, "MM/yy")}
+                                    />
+                                </div>
+                            </TooltipTrigger>
+                            <TooltipContent
+                                className="z-1000"
+                                side="top"
+                                align="center"
+                            >
+                                <p className="font-paragraph bg-primary">Click {card.name} for more details</p>
+                            </TooltipContent>
+
+                        </Tooltip>
+                    ))}
+                    autoplayDelay={5000}
+                    slideShadows={false}
+                />
 
 
+
+            </TooltipProvider>
+            {/*Add a button if less then 2 credit cards (from spec)*/}
+            {account.accountType.name.toLowerCase()!=="business" //TODO: CHECK WITH BACKEND ACC TYPE
+                && cards.length < 2
+                && NewCreditCardButton
+            }
+
+        </div>
+    )
+
+}
 
 const BankAccountCardsCard = ({ account, className, ...props }: BalanceCardProps) => {
 
@@ -42,12 +104,27 @@ const BankAccountCardsCard = ({ account, className, ...props }: BalanceCardProps
         modifiedAt: new Date(),
     }
 
-    const cards = [card, card];
+    const cards: CardEntity[] = [card, card];
     const navigate = useNavigate();
 
     const handleCardClick = (cardId: string) => {
         navigate(`/cards/${cardId}`); // Navigate to the card's route
     };
+
+    const cardsList = () => {
+        if (cards.length === 0) {
+            return (
+                <>
+                    <CardDescription className="font-paragraph flex flex-col items-center gap-4">
+                        You do not have any cards for this bank account.
+                        {NewCreditCardButton}
+                    </CardDescription>
+
+                </>
+            )
+        }
+        else return CreditCardSwipe(account, cards, handleCardClick);
+    }
 
     return (
         <Card
@@ -61,45 +138,7 @@ const BankAccountCardsCard = ({ account, className, ...props }: BalanceCardProps
                 <CardTitle className="font-heading text-2xl">Cards</CardTitle>
             </CardHeader>
             <CardContent>
-                <TooltipProvider>
-
-                    <CardSwipe
-                        elements={cards.map((card) => (
-                            <Tooltip>
-                                {/* Wrap tooltip content in TooltipTrigger */}
-                                <TooltipTrigger>
-
-                                    <div
-                                        onClick={() => handleCardClick(card.id)}
-                                        className="cursor-pointer inline-block w-full"
-                                        onMouseDown={(e) => e.preventDefault()}
-                                    >
-                                        <CreditCard
-                                            title={card.name}
-                                            cardHolder={`${card.account.client.firstName} ${card.account.client.lastName}`}
-                                            cardNumber={card.number}
-                                            expiryDate={format(card.expiresAt, "MM/yy")}
-                                        />
-                                    </div>
-                                </TooltipTrigger>
-                                <TooltipContent
-                                    className="z-1000"
-                                    side="top"
-                                    align="center"
-                                >
-                                    <p className="font-paragraph bg-primary">Click {card.name} for more details</p>
-                                </TooltipContent>
-
-                            </Tooltip>
-                        ))}
-                        autoplayDelay={5000}
-                        slideShadows={false}
-                    />
-
-
-
-                </TooltipProvider>
-
+                {cardsList()}
             </CardContent>
         </Card>
     );

--- a/src/components/bank-account/BankAccountDetails.tsx
+++ b/src/components/bank-account/BankAccountDetails.tsx
@@ -55,7 +55,7 @@ const BankAccountDetailsCard = ({
     return (
         <Card
             className={cn(
-                "border-0 content-center",
+                "h-full border-0 content-center",
                 className
             )}
             {...props}

--- a/src/components/bank-account/BankAccountTransactions.tsx
+++ b/src/components/bank-account/BankAccountTransactions.tsx
@@ -18,7 +18,7 @@ const BankAccountTransactionsCard = ({ account, className, ...props }:BankAccoun
             </CardHeader>
             <CardContent>
             <Tabs defaultValue="transactions">
-                <TabsList className="grid w-full grid-cols-2 font-paragraph bg-gray-700">
+                <TabsList className="grid w-full md:grid-cols-2 font-paragraph bg-gray-700 sm:grid-cols-1 sm:h-full">
                     <TabsTrigger value="transactions">
                         Transactions
                        </TabsTrigger>

--- a/src/components/ui/card-swipe.tsx
+++ b/src/components/ui/card-swipe.tsx
@@ -43,12 +43,12 @@ export const CardSwipe: React.FC<CarouselProps> = ({
                 cardsEffect={{
                   slideShadows: slideShadows,
                 }}
-                className="!max-size-full "
+                className="!max-w-full w-80"
 
                 modules={[EffectCards, Autoplay, Pagination, Navigation]}
               >
                 {elements.map((element, index) => (
-                  <SwiperSlide key={index} className="!size-fit !max-size-full rounded-2xl  flex justify-center">
+                  <SwiperSlide key={index} className="!flex !items-center !justify-center rounded-2xl">
 
                         {element}
 

--- a/src/components/ui/card-swipe.tsx
+++ b/src/components/ui/card-swipe.tsx
@@ -43,12 +43,12 @@ export const CardSwipe: React.FC<CarouselProps> = ({
                 cardsEffect={{
                   slideShadows: slideShadows,
                 }}
-                className="!max-w-90 !w-90 "
+                className="!max-size-full "
 
                 modules={[EffectCards, Autoplay, Pagination, Navigation]}
               >
                 {elements.map((element, index) => (
-                  <SwiperSlide key={index} className="!size-fit rounded-2xl  flex justify-center">
+                  <SwiperSlide key={index} className="!size-fit !max-size-full rounded-2xl  flex justify-center">
 
                         {element}
 

--- a/src/components/ui/credit-card.tsx
+++ b/src/components/ui/credit-card.tsx
@@ -88,7 +88,7 @@ const CreditCard = React.forwardRef<HTMLDivElement, CreditCardProps>(
 
         <motion.div
           className={cn(
-            "relative h-48 w-80 overflow-hidden rounded-xl p-6 shadow-xl",
+            "relative overflow-hidden rounded-xl p-6 px-10 shadow-xl",
               randomGradient
           )}
           initial={{ opacity: 0, y: 50 }}

--- a/src/pages/BankAccount.tsx
+++ b/src/pages/BankAccount.tsx
@@ -115,7 +115,7 @@ export default function BankAccountPage() {
                 </AnimatePresence>
 
                 <BankAccountCardsCard account={account} />
-                <BankAccountTransactions className="col-span-2" account={account}/>
+                <BankAccountTransactions className="md:col-span-2 sm:col-span-1" account={account}/>
             </div>
         </main>
     )

--- a/src/pages/BankAccountList.tsx
+++ b/src/pages/BankAccountList.tsx
@@ -19,8 +19,8 @@ export default function BankAccountListPage() {
 
             <div className="fixed bottom-4 md:right-4 right-1/2 transform translate-x-1/2 md:translate-x-0 z-50 -mr-2 -mb-2">
                 <Button className="size16 rounded-4xl" variant="success"   onClick={() => setDialogOpen(true)} >
-                    Create a new bank account
                     <span className="icon-[ph--plus] text-lg"></span>
+                    Create a new bank account
                 </Button>
             </div>
 

--- a/src/pages/UserList.tsx
+++ b/src/pages/UserList.tsx
@@ -17,8 +17,9 @@ export default function UserListPage() {
                     variant="success"
                     onClick={() => setDialogOpen(true)}
                 >
-                    Register a new employee
                     <span className="icon-[ph--user-plus] text-lg"></span>
+                    Register a new employee
+
                 </Button>
             </div>
 


### PR DESCRIPTION
# Added "New card" button
Introduced a button used for adding new credit cards. The button appears only if the client can add a new card (has available card slots). Examples:
>Example 1: No credit cards
![image](https://github.com/user-attachments/assets/e705a9cc-65ef-4021-8eba-1f99457bd9df)

>Example 2: One credit card
![image](https://github.com/user-attachments/assets/8fccc1f1-a0e0-47ad-824f-f34538c4695b)

>Example 3: Two credit cards (maximum allowed number of cards)
![image](https://github.com/user-attachments/assets/c50e592f-5953-447b-8461-ba0d8c06a7e7)

### *TODO*:
* Open add credit card dialog/drawer on button click.
* Check with backend and specification how to work with business accounts.

# Fixed responsive design of BankAccount.tsx
Put cards in a single column for small screens (e.g. mobile). Applied minor changes for small screens.